### PR TITLE
Add docker-compose setup and dockerignore for improved developer experience

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# Git & VCS
+.git
+.gitignore
+.github
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.pytest_cache/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Node / Frontend
+frontend/node_modules/
+frontend/dist/
+frontend/build/
+npm-debug.log
+yarn-error.log
+
+# OS / Editor junk
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Large generated artifacts
+data/
+dataset_output/
+batch_results/
+ghidra_output/
+ghidra_json/
+features.csv
+features.txt
+
+# ML artifacts
+*.pt
+*.pth
+*.ckpt
+*.onnx
+*.joblib
+ml/runs/
+ml/checkpoints/
+
+# Logs
+*.log
+logs/
+
+# Secrets
+.env
+.env.*
+*.pem
+*.key
+*.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: vestigo-backend
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./data:/opt/vestigo/data
+      - ./backend/prisma:/app/backend/prisma
+    tty: true
+    stdin_open: true
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    container_name: vestigo-frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend


### PR DESCRIPTION
This PR improves Vestigo’s local development experience by adding a standardized Docker Compose (`docker-compose.yml`) setup and a `.dockerignore` file. These changes reduce Docker build context size, prevent accidental inclusion of generated artifacts and secrets, and make local builds more reliable and reproducible across environments.

Closes #50