### PR TITLE
fix: remove leading whitespace in FS_SCAN endpoint

### DIFF
--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -11,7 +11,7 @@ export const API_CONFIG = {
     JOB_CFG: (jobId: string) => `/job/${jobId}/cfg`,
     JOB_CFG_IMAGE: (jobId: string) => `/job/${jobId}/cfg/image`,
     EXTRACT_FEATURES: (jobId: string) => `/job/${jobId}/extract-features`,
-    FS_SCAN: (jobId: string) => ` /job/${jobId}/fs-scan`,
+    FS_SCAN: (jobId: string) => `/job/${jobId}/fs-scan`,
   }
 };
 


### PR DESCRIPTION
## Description
Remove leading whitespace in FS_SCAN endpoint

### Type of Change

<!-- Mark the relevant option with an x -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)  
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting changes
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🔒 Security fix
- [ ] 🏗️ Build/CI changes

## Related Issues



Closes #20 
Related to #20 

## Changes Made

Removed the extra whitespace to the start of the the url.

@BhoomiAgrawal12 